### PR TITLE
Add order persistence to Cosmos DB

### DIFF
--- a/basicDemo.md
+++ b/basicDemo.md
@@ -83,3 +83,15 @@ Documentation is created:
 ### 5. Optionally test the code to demonstrate end-to-end functionality
 
 ![End-to-End test](./media/basicDemo/13_testrun.png)
+
+### 6. Persisting the Order Object to Cosmos DB
+
+To enhance our REST API, we've now included functionality to persist the order object to Cosmos DB. This involves initializing a Cosmos DB client, parsing the HTTP request into an `Order` object, and then persisting this object to Cosmos DB. Here's a brief overview of the steps involved:
+
+1. **Initialize Cosmos DB Client**: At the start of our function, we initialize a Cosmos DB client using the connection string stored in our local settings.
+
+2. **Parse HTTP Request**: We parse the incoming HTTP request to extract the order details and serialize them into an `Order` object.
+
+3. **Persist to Cosmos DB**: Finally, we use the Cosmos DB client to persist the `Order` object to our database.
+
+This addition ensures that every order processed by our REST API is now stored in Cosmos DB, allowing for further processing and analysis down the line.

--- a/src/demo/basic/HttpTrigger1.cs
+++ b/src/demo/basic/HttpTrigger1.cs
@@ -7,11 +7,20 @@ using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
+using Microsoft.Azure.Cosmos;
 
 namespace Company.Function
 {
     public static class HttpTrigger1
     {
+        private static CosmosClient cosmosClient;
+        private static Container cosmosContainer;
+
+        static HttpTrigger1()
+        {
+            cosmosClient = new CosmosClient(Environment.GetEnvironmentVariable("CosmosDBConnectionString"));
+            cosmosContainer = cosmosClient.GetContainer("OrderDatabase", "OrderContainer");
+        }
 
         [FunctionName("HttpTrigger1")]
         public static async Task<IActionResult> Run(
@@ -20,7 +29,26 @@ namespace Company.Function
         {
             log.LogInformation("C# HTTP trigger function processed a request.");
 
-            return new OkObjectResult("response");
+            string requestBody = await new StreamReader(req.Body).ReadToEndAsync();
+            Order order = JsonConvert.DeserializeObject<Order>(requestBody);
+
+            try
+            {
+                ItemResponse<Order> response = await cosmosContainer.CreateItemAsync(order, new PartitionKey(order.OrderID));
+                return new OkObjectResult($"Order with ID: {order.OrderID} added to Cosmos DB.");
+            }
+            catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.Conflict)
+            {
+                return new ConflictObjectResult($"Order with ID: {order.OrderID} already exists.");
+            }
         }
+    }
+
+    public class Order
+    {
+        [JsonProperty("id")]
+        public string OrderID { get; set; }
+        public string ProductID { get; set; }
+        public int Quantity { get; set; }
     }
 }

--- a/src/demo/basic/Order.cs
+++ b/src/demo/basic/Order.cs
@@ -1,0 +1,12 @@
+using Newtonsoft.Json;
+
+namespace Company.Function
+{
+    public class Order
+    {
+        [JsonProperty("id")]
+        public string OrderID { get; set; }
+        public string ProductID { get; set; }
+        public int Quantity { get; set; }
+    }
+}

--- a/src/demo/basic/local.settings.json
+++ b/src/demo/basic/local.settings.json
@@ -1,0 +1,8 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "FUNCTIONS_WORKER_RUNTIME": "dotnet",
+    "CosmosDBConnectionString": "AccountEndpoint=https://<your-cosmos-db-account>.documents.azure.com:443/;AccountKey=<your-cosmos-db-account-key>;"
+  }
+}


### PR DESCRIPTION
Implements a REST interface in the function app to accept an order request, parse it into an order object, and persist it to Cosmos DB.

- **Updates `HttpTrigger1.cs`**: Adds Azure Cosmos DB SDK, initializes a Cosmos DB client, parses the HTTP request into an `Order` object, and persists the object to Cosmos DB. Also includes error handling for duplicate orders.
- **Introduces `Order.cs`**: Adds a new class to define the structure of the order object with `OrderID`, `ProductID`, and `Quantity` properties.
- **Adds `local.settings.json`**: Includes a new file to store local settings, such as the Cosmos DB connection string.
- **Revises `basicDemo.md`**: Updates documentation to include steps for persisting the order object to Cosmos DB, enhancing the REST API's functionality.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Lantern-Cloud-Services/MTC_GHCopilot_SB?shareId=1e9cdfaf-bac7-4a1d-a31a-ed43c857911d).